### PR TITLE
GHC 9.4 compatibility

### DIFF
--- a/rounded-hw/src/Numeric/Rounded/Hardware/Backend/FastFFI.hs
+++ b/rounded-hw/src/Numeric/Rounded/Hardware/Backend/FastFFI.hs
@@ -173,7 +173,7 @@ foreign import prim "rounded_hw_interval_sqrt"
                         , Double#  -- upper, %xmm2
                         #)
 
-#if WORD_SIZE_IN_BITS >= 64
+#if WORD_SIZE_IN_BITS >= 64 && !MIN_VERSION_base(4,17,0)
 type INT64# = Int#
 type WORD64# = Word#
 #else


### PR DESCRIPTION
As mentioned in the [GHC 9.4 migration guide](https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.4#word64int64-use-word64int64), starting from `base >= 4.17`, `Int64` and `Word64` are unconditionally backed by `Int64#` and `Word64#`.

This simple change fixes the type error in `Numeric.RFounded.Hardware.Backend.FastFFI.fastIntervalFromInt64` on GHC 9.4.

I noticed that this function is not exported, and not used anywhere else, and same with `fastIntervalSqrt`. Is that intended?